### PR TITLE
Please don't delete Maldet's daily cron.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ This module has been tested with Maldet verions:
 
 By default Maldet is installed from source using the Maldet {} type/provider. If you prefer to use a package, simply use the "package_name" parameter to specify the name of your package, and it will use that instead (assuming any necessary repositories have been enabled).
 
-Maldet will setup a cronjob that runs a daily scan on certain paths on the servers home directory depending on what directories it sees as present on a server.
+Maldet will setup a daily cronjob that provides the following capabilities:
 
-It will also setup an inotify service to watch and scan changed files under certain directories (set to /tmp, /var/tmp, /dev/shm, and /var/fcgi_ipc by default).
+* Autoupdate Maldet version.
+* Autoupdate Maldet signatures.
+* Send a daily or weekly report of file creation/modify/move operations to email recipients if monitor mode is selected.
+* If monitor mode is *not* selected, a daily scan of recent file changes is performed. The scan supports a variety of common control panel systems or standard Linux /home\*/user paths.
+* Cleanup session, temp and quarantine data.
 
-Both the cron job and service are managed by the daily_scan and service_ensure parameters, respectively.
+If monitor mode is enabled, Maldet will also setup an inotify service to watch and scan changed files under certain directories (set to /tmp, /var/tmp, /dev/shm, and /var/fcgi_ipc by default).
+
+The Maldet service is managed by the service_ensure parameter.
 
 ## Usage
 
@@ -62,10 +68,6 @@ Whether to install or remove maldet. Valid values are "present" or "absent".
 #### `service_ensure` _String_ ('running')
 
 Whether the maldet inotify monitor service should be running.
-
-#### `daily_scan` _Boolean_ (true)
-
-Whether to enable maldet's daily scan cron job.
 
 #### `mirror_url` _String_ ('https://www.rfxn.com/downloads')
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,6 @@ maldet::version: '1.5'
 maldet::package_name: ''
 maldet::ensure: present
 maldet::service_ensure: running
-maldet::daily_scan: true
 maldet::mirror_url: https://www.rfxn.com/downloads
 maldet::config: {}
 maldet::monitor_paths:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,6 @@ class maldet::config (
   Array   $ignore_sigs     = $maldet::ignore_sigs,
   Hash    $cron_config     = $maldet::cron_config,
   String  $version         = $maldet::version,
-  Boolean $daily_scan      = $maldet::daily_scan,
 ) {
 
   # Versions of maldet < 1.5 use a different set of
@@ -93,11 +92,5 @@ class maldet::config (
     owner   => root,
     group   => root,
     content => join($ignore_sigs, "\n"),
-  }
-
-  unless $daily_scan {
-    file { '/etc/cron.daily/maldet':
-      ensure => absent,
-    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,6 @@
 # @param package_name Optional package name to use. Will install from source if left empty. Defaults to ''
 # @param ensure Whether to install or remove maldet. Valid values are "present" or "absent". Defaults to 'present'
 # @param service_ensure Whether the maldet inotify monitor service should be running
-# @param daily_scan Whether to enable maldet's daily scan cron job. Defaults to true.
 # @param mirror_url Base URL to download maldet source tarball from. Defaults to 'https://www.rfxn.com/downloads'
 # @param config Hash of config options to use. Booleans are converted to 0 or 1. options with multiple values such as 
 #        email_addr and scan_tmpdir_paths should be specified as an Array.
@@ -27,7 +26,6 @@ class maldet (
   String  $package_name,
   String  $ensure,
   String  $service_ensure,
-  Boolean $daily_scan,
   String  $mirror_url,
   Hash    $config,
   Array   $monitor_paths,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -44,8 +44,7 @@ describe 'maldet' do
       describe 'maldet::config' do
         let(:params) {{ :config => {},
                         :cron_config => {},
-                        :version => '1.5',
-                        :daily_scan => true }}
+                        :version => '1.5' }}
         it { should contain_file('/usr/local/maldetect/conf.maldet').
              with(:ensure => 'present') }
         it { should contain_file('/usr/local/maldetect/cron/conf.maldet.cron').
@@ -55,12 +54,6 @@ describe 'maldet' do
           let(:params) {{ :version => '1.4.2' }}
           it { should_not contain_file('/usr/local/maldetect/cron/conf.maldet.cron').
                with(:ensure => 'present') }
-        end
-
-        describe 'remove daily cron if daily_scan option is toggled' do
-          let(:params) {{ :daily_scan=> false }}
-          it { should contain_file('/etc/cron.daily/maldet').
-               with(:ensure => 'absent') }
         end
       end
 


### PR DESCRIPTION
The daily cron provides many features beyond a daily scan. The daily scan only
occurs if monitor mode is not enabled.

Important features provided by the daily cron are:

* autoupdate of Maldet software
* autoupdate of Maldet signatures
* cleanup of session, temp and quarantine
* daily or weekly email report when monitor mode is in use
* daily scan of file structure when monitor mode is *not* in use

The only way to replace the daily cron script seems to be with an update to the
software.

```
maldet -d
```

If there is no update, then no new script is created. A user who sets
daily_scan to false will be stuck for a period of time without the features
listed above.

See: https://github.com/rfxn/linux-malware-detect/blob/master/README#L306-L316