### PR TITLE
Fix ruby syntax error that breaks the uninstall process.

### DIFF
--- a/lib/puppet/provider/maldet/source.rb
+++ b/lib/puppet/provider/maldet/source.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:maldet).provide(:source) do
 
   def destroy
     Dir.chdir('/usr/local/maldetect/') do
-      if File.exists('./uninstall.sh')
+      if File.exists?('./uninstall.sh')
         %x{ echo y | ./uninstall.sh }
       else
         puts 'Unable to locate uninstall script (this script is not provided in Maldet versions < 1.5).'


### PR DESCRIPTION
The missing "?" causes the following error.

Error: Could not set 'absent' on ensure: undefined method `exists' for File:Class at /tmp/vagrant-puppet/modules-001663b571c9809ae1951a992dc8dd08/maldet/manifests/install.pp:33

Puppet 4.10.6 was used when testing this.