### PR TITLE
Fix uninstall process to get rid of Puppet errors.

### DIFF
--- a/lib/puppet/provider/maldet/source.rb
+++ b/lib/puppet/provider/maldet/source.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:maldet).provide(:source) do
 
   def destroy
     Dir.chdir('/usr/local/maldetect/') do
-      if File.exists('./uninstall.sh')
+      if File.exists?('./uninstall.sh')
         %x{ echo y | ./uninstall.sh }
       else
         puts 'Unable to locate uninstall script (this script is not provided in Maldet versions < 1.5).'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,10 +41,13 @@ class maldet (
 ) {
 
   contain maldet::install
-  contain maldet::config
-  contain maldet::service
 
-  Class['maldet::install'] ~>
-  Class['maldet::config'] ~>
-  Class['maldet::service']
+  if $ensure == 'present' {
+    contain maldet::config
+    contain maldet::service
+
+    Class['maldet::install'] ~>
+    Class['maldet::config'] ~>
+    Class['maldet::service']
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,11 +14,6 @@ class maldet::install (
   # inotify-tools is used by the maldet service
   ensure_packages(['psmisc', 'wget', 'cpulimit', 'inotify-tools', 'perl'])
 
-  file { ['/usr/sbin/maldet', '/usr/sbin/lmd']:
-    ensure => link,
-    target => '/usr/local/maldetect/maldet',
-  }
-
   if $manage_epel and $::facts['os']['family'] == 'Redhat' {
     include ::epel
     Class['epel'] ->


### PR DESCRIPTION
Puppet complains about file and service resource that it can no longer manage
because Maldetect's uninstall.sh script has removed them.

Let's only run ::maldet::config and ::maldet::service if `$ensure ==
'present'`. This way we get a clean install and uninstall Puppet run.