### PR TITLE
If maldet version is >= 1.5, use conf.maldet.cron for custom config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ List of paths to exclude from scans.
 
 List of signatures to exclude.
 
-#### `cron_config` _Hash_ ({})
-
-Separate hash of config options to override main config options during maldet's daily cron job.
-
 #### `cleanup_old_install` _Boolean_ (true)
 
 Whether old backups of /usr/local/maldetect created by Maldet's install.sh should be removed.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,24 +21,24 @@ class maldet::config (
     $merged_config = $default_config + $config
   }
 
-  $merged_conf = { 'config' => $merged_config }
-  file { '/usr/local/maldetect/conf.maldet':
-    ensure  => present,
-    mode    => '0644',
-    owner   => root,
-    group   => root,
-    content => epp('maldet/conf.maldet.epp', $merged_conf),
-  }
-
   # Allow config overrides for daily cron
-  $cron_conf = { 'config' => $cron_config }
+  $merged_conf = { 'config' => $merged_config }
   if versioncmp($maldet::version, '1.5') >= 0 {
     file { '/usr/local/maldetect/cron/conf.maldet.cron':
       ensure  => present,
       mode    => '0644',
       owner   => root,
       group   => root,
-      content => epp('maldet/conf.maldet.epp', $cron_conf),
+      content => epp('maldet/conf.maldet.epp', $merged_conf),
+    }
+  }
+  else {
+    file { '/usr/local/maldetect/conf.maldet':
+      ensure  => present,
+      mode    => '0644',
+      owner   => root,
+      group   => root,
+      content => epp('maldet/conf.maldet.epp', $merged_conf),
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,6 @@
 # @param config Hash of config options to use. Booleans are converted to 0 or 1. options with multiple values such as 
 #        email_addr and scan_tmpdir_paths should be specified as an Array.
 # @see https://www.rfxn.com/appdocs/README.maldetect
-# @param cron_config Separate hash of config options for maldet's daily cron job.
 # @param monitor_paths list of paths that the maldet service should monitor files under. Note that directories containing large numbers of files will lead to long startup times for the maldet service.
 # @param ignore_file_ext list of file extensions to ignore
 # @param ignore_inotify list of paths to exclude from inotify monitor mode
@@ -35,7 +34,6 @@ class maldet (
   Array   $ignore_inotify,
   Array   $ignore_paths,
   Array   $ignore_sigs,
-  Hash    $cron_config,
   Boolean $cleanup_old_install,
   Boolean $manage_epel,
 ) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -43,17 +43,16 @@ describe 'maldet' do
 
       describe 'maldet::config' do
         let(:params) {{ :config => {},
-                        :cron_config => {},
                         :version => '1.5',
                         :daily_scan => true }}
-        it { should contain_file('/usr/local/maldetect/conf.maldet').
-             with(:ensure => 'present') }
         it { should contain_file('/usr/local/maldetect/cron/conf.maldet.cron').
              with(:ensure => 'present') }
 
         describe 'do not create conf.maldet.cron on older versions' do
           let(:params) {{ :version => '1.4.2' }}
           it { should_not contain_file('/usr/local/maldetect/cron/conf.maldet.cron').
+               with(:ensure => 'present') }
+          it { should contain_file('/usr/local/maldetect/conf.maldet').
                with(:ensure => 'present') }
         end
 


### PR DESCRIPTION
As of Maldetect version 1.5, the conf.maldet.cron file has been available for overriding
default maldet cron values. Let's only use this file. That way, we can leave
the conf.maldet file untouched.

This should also benefit us when newer versions of maldet need to
provide new key=value pairs. Those pairs will show up in the unmanaged
conf.maldet file and just work. Then we can choose to override the values if
necessary.

See the following links:
https://github.com/rfxn/linux-malware-detect/blob/master/CHANGELOG#L197
https://github.com/rfxn/linux-malware-detect/blob/master/cron.daily#L29-L31
https://github.com/rfxn/linux-malware-detect/blob/master/files/internals/internals.conf#L124