### PR TITLE
Adding new cron options and default values for Maldetect version 1.6.2

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-maldet::version: '1.5'
+maldet::version: '1.6'
 maldet::package_name: ''
 maldet::ensure: present
 maldet::service_ensure: running
@@ -37,10 +37,12 @@ maldet::new_config:
   autoupdate_signatures: true
   autoupdate_version: false
   autoupdate_version_hashed: true
+  cron_prune_days: 21
   import_config_url: ''
   import_config_expire: 43200
   import_sigs_md5_url: ''
   import_sigs_hex_url: ''
+  scan_days: 1
   scan_max_depth: 15
   scan_min_filesize: 24
   scan_max_filesize: 768k

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,7 +18,7 @@ describe 'maldet' do
       end
 
       describe 'maldet::install' do
-        let(:params) {{ :version => '1.5',
+        let(:params) {{ :version => '1.6',
                         :mirror_url => 'https://www.rfxn.com/downloads',
                         :package_name => '',
                         :ensure => 'present',
@@ -44,7 +44,7 @@ describe 'maldet' do
       describe 'maldet::config' do
         let(:params) {{ :config => {},
                         :cron_config => {},
-                        :version => '1.5',
+                        :version => '1.6',
                         :daily_scan => true }}
         it { should contain_file('/usr/local/maldetect/conf.maldet').
              with(:ensure => 'present') }


### PR DESCRIPTION
These options were made available in v.1.6.1. Let's provide them with their default values.

See the following links:

cron_prune_days
https://github.com/rfxn/linux-malware-detect/blob/master/CHANGELOG#L7
https://github.com/rfxn/linux-malware-detect/blob/master/cron.daily#L37-L39

scan_days
https://github.com/rfxn/linux-malware-detect/blob/master/CHANGELOG#L76
https://github.com/rfxn/linux-malware-detect/blob/master/cron.daily#L33-L35