### PR TITLE
Set monitor mode in /etc/sysconfig/maldet for OS Family redhat machines.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,7 +45,7 @@ class maldet::config (
   # MONITOR_MODE is commented out by default and can prevent maldet service
   # from starting when using the init based startup script.
   $monitor_mode = { 'monitor_mode' => $merged_config['default_monitor_mode'] }
-  if $::facts['service_provider'] == 'redhat' {
+  if $::facts['os']['family'] == 'redhat' {
     file { '/etc/sysconfig/maldet':
       ensure  => present,
       mode    => '0644',


### PR DESCRIPTION
The service_provider fact on a RedHat Enterprise Linux machine is redhat. But,
on a CentOS machine, it's systemd. I think we still want to manage the
configuration of /etc/sysconfig/maldet, as long as the machine's OS is part of
the RedHat OS family.

Let's just use facts['os']['family'] to determine whether to attempt to manage
the /etc/sysconfig/maldet.