### PR TITLE
Use regex for ignore_paths entries

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,8 +24,8 @@ maldet::ignore_inotify:
   - ^/dev/pts*
   - ^/dev/null
 maldet::ignore_paths:
-  - /usr/local/maldetect
-  - /usr/local/sbin/maldet
+  - ^/usr/local/maldetect$
+  - ^/usr/local/sbin/maldet$
 maldet::ignore_sigs: []
 
 # Config defaults for Linux Malware Detect > 1.5


### PR DESCRIPTION
Otherwise you could have malware in
/some/path/here/usr/local/maldetect/malware and it would be excluded
from the scan.