### PR TITLE
Linting and Test Cleanup/Additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 Gemfile.lock
 log/
 junit/
+/batect

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,12 @@ end
 # if using ruby 1.x for puppet 3.2 through puppet 3.4
 gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
 
+## metadata-json-lint does this, but incorrectly so, which causes issues for ruby21
+gem 'public_suffix', '< 3' if RUBY_VERSION < '2.3'
+
+## another dependency w/"recent" version requirement updates
+gem 'net-ssh', '< 5' if RUBY_VERSION < '2.2'
+
 group :development do
   gem "puppet-blacksmith"
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,8 +46,8 @@ class maldet (
     contain maldet::config
     contain maldet::service
 
-    Class['maldet::install'] ~>
-    Class['maldet::config'] ~>
-    Class['maldet::service']
+    Class['maldet::install']
+    ~> Class['maldet::config']
+    ~> Class['maldet::service']
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,12 +16,12 @@ class maldet::install (
 
   if $manage_epel and $::facts['os']['family'] == 'Redhat' {
     include ::epel
-    Class['epel'] ->
-    Package['psmisc'] ->
-    Package['wget'] ->
-    Package['cpulimit'] ->
-    Package['inotify-tools'] ->
-    Package['perl']
+    Class['epel']
+    -> Package['psmisc']
+    -> Package['wget']
+    -> Package['cpulimit']
+    -> Package['inotify-tools']
+    -> Package['perl']
   }
 
   if $package_name == '' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,10 +28,6 @@ describe 'maldet' do
         it { should contain_package('cpulimit').with(:ensure => 'present') }
         it { should contain_package('inotify-tools').with(:ensure => 'present') }
         it { should contain_package('perl').with(:ensure => 'present') }
-        it { should contain_file('/usr/sbin/maldet').
-             with(:ensure => 'link') }
-        it { should contain_file('/usr/sbin/lmd').
-             with(:ensure => 'link') }
         it { should contain_maldet('https://cdn.rfxn.com/downloads').
              with(:ensure => 'present') }
 

--- a/spec/puppet4.yml
+++ b/spec/puppet4.yml
@@ -1,0 +1,62 @@
+project_name: puppet-config-puppet5
+
+containers:
+  ruby21:
+    image: ruby:2.1
+    volumes:
+      - local: ../
+        container: /code
+        options: cached
+    working_directory: /code
+    environment:
+      BUNDLE_PATH: /code/.bundle
+      PUPPET_GEM_VERSION: '~> 4.10'
+    run_as_current_user:
+      enabled: true
+      home_directory: /home/container-user
+
+tasks:
+  bundleInstall:
+    description: 'Run Bundler'
+    group: 'Setup Tasks'
+    run:
+      container: ruby21
+      command: bundle install
+
+  validate:
+    description: 'Run Puppet Parser Validate'
+    group: 'Lint Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby21
+      command: bundle exec rake validate
+
+  puppetLint:
+    description: 'Run Puppet Lint'
+    group: 'Lint Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby21
+      command: bundle exec rake lint
+
+  runSpec:
+    description: 'Run Spec Tests'
+    group: 'Test Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby21
+      command: bundle exec rake spec SPEC_OPTS='--format documentation'
+
+  runAll:
+    description: 'Run All Tasks'
+    group: 'Lint Tasks'
+    prerequisites:
+      - validate
+      - puppetLint
+      - runSpec
+    run:
+      container: ruby21
+      command: /bin/true

--- a/spec/puppet5.yml
+++ b/spec/puppet5.yml
@@ -1,0 +1,62 @@
+project_name: puppet-config-puppet5
+
+containers:
+  ruby24:
+    image: ruby:2.4
+    volumes:
+      - local: ../
+        container: /code
+        options: cached
+    working_directory: /code
+    environment:
+      BUNDLE_PATH: /code/.bundle
+      PUPPET_GEM_VERSION: '~> 5.5'
+    run_as_current_user:
+      enabled: true
+      home_directory: /home/container-user
+
+tasks:
+  bundleInstall:
+    description: 'Run Bundler'
+    group: 'Setup Tasks'
+    run:
+      container: ruby24
+      command: bundle install
+
+  validate:
+    description: 'Run Puppet Parser Validate'
+    group: 'Lint Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby24
+      command: bundle exec rake validate
+
+  puppetLint:
+    description: 'Run Puppet Lint'
+    group: 'Lint Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby24
+      command: bundle exec rake lint
+
+  runSpec:
+    description: 'Run Spec Tests'
+    group: 'Test Tasks'
+    prerequisites:
+      - bundleInstall
+    run:
+      container: ruby24
+      command: bundle exec rake spec SPEC_OPTS='--format documentation'
+
+  runAll:
+    description: 'Run All Tasks'
+    group: 'Lint Tasks'
+    prerequisites:
+      - validate
+      - puppetLint
+      - runSpec
+    run:
+      container: ruby24
+      command: /bin/true


### PR DESCRIPTION
Looks like even tho the tests have been updated, and there's a travis config, nothing has actually been validating those. In the process of validating compatibility for Puppet 5, I realized there were a few issues. This addresses those, as well as adds batect tests to easily run the test independent of environment. Removed tests are due to changes made in 943600873cb1526cbd72791ed7ffd5db8a9ad222.

Will eventually enable travis and configure it to use these tests as well.