### PR TITLE
Release 3.0.0 Updates

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "nexcess-maldet",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "nexcess",
   "summary": "Install and configure Linux Malware Detect",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -9,12 +9,6 @@
   "issues_url": "https://github.com/nexcess/puppet-maldet/issues",
   "operatingsystem_support": [
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",

--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,6 @@
   "source": "https://github.com/nexcess/puppet-maldet",
   "project_page": "https://github.com/nexcess/puppet-maldet",
   "issues_url": "https://github.com/nexcess/puppet-maldet/issues",
-  "tags": [],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Ubuntu",
@@ -34,17 +32,17 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     },
     {
-      "name": "stahnma-epel",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "name": "puppet-epel",
+      "version_requirement": ">= 1.0.0 < 4.0.0"
     }
   ]
 }


### PR DESCRIPTION
Bumping the versions and dependencies in metadata to support modern versions.

Additionally starting with the 3.0.0 release, Ubuntu will no longer be a supported platform. We will continue forward supporting only CentOS/RHEL 6 and 7.