### PR TITLE
Add Debian support (sysconfig path)

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -31,6 +31,7 @@ maldet::monitor_mode: 'disabled'
 maldet::cron_config: {}
 maldet::cleanup_old_install: true
 maldet::manage_epel: true
+maldet::sysconfig_path: '/etc/sysconfig/maldet'
 
 # Config defaults for Linux Malware Detect > 1.5
 maldet::new_config:

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+---
+maldet::sysconfig_path: '/etc/default/maldet'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+maldet::sysconfig_path: '/etc/sysconfig/maldet'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -4,6 +4,17 @@ defaults:
   datadir: data
   data_hash: yaml_data
 hierarchy:
+  - name: "osfamily/major release"
+    paths:
+        # Used to distinguish between Debian and Ubuntu
+      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
+      - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+        # Used for Solaris
+      - "os/%{facts.os.family}/%{facts.kernelrelease}.yaml"
+  - name: "osfamily"
+    paths:
+      - "os/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"
   - name: "common data"
     path: "common.yaml"
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class maldet::config (
   Boolean $daily_scan      = $maldet::daily_scan,
   Array   $monitor_paths   = $maldet::monitor_paths,
   Variant[Enum['disabled', 'users'], Stdlib::Absolutepath] $monitor_mode = $maldet::monitor_mode,
+  String  $sysconfig_path  = $maldet::sysconfig_path,
 ) {
 
   # Versions of maldet < 1.5 use a different set of
@@ -45,7 +46,7 @@ class maldet::config (
 
   # MONITOR_MODE is commented out by default and can prevent maldet service
   # from starting when using the init based startup script.
-  file { '/etc/sysconfig/maldet':
+  file { $sysconfig_path:
     ensure  => present,
     mode    => '0644',
     owner   => root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@
 # @param monitor_mode string matching one of the following: A. the word `disabled`, which will disable monitor mode.
 #        B. the word `users`, which will monitor all local linux users. C. an absolute path to a file containing a
 #        list of users to monitor.
+# @param sysconfig_path Path to sysconfig file, generally set by module per OS.
 #
 #
 class maldet (
@@ -42,6 +43,7 @@ class maldet (
   Boolean $cleanup_old_install,
   Boolean $manage_epel,
   Variant[Enum['disabled', 'users'], Stdlib::Absolutepath] $monitor_mode,
+  String  $sysconfig_path,
 ) {
 
   contain maldet::install


### PR DESCRIPTION
This is a fairly simple tweak to make this module work under Ubuntu.  Really it's just making the hardcoded sysconfig path configurable.  I did not adjust any spec tests or metadata.json or anything, just kept with the minor tweaks.