### PR TITLE
drop support for maldet < 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 This module installs and configures Linux Malware Detect (Maldet)
 
 This module has been tested with Maldet verions:
-  - 1.4.x
   - 1.5
   - 1.6
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,7 +5,6 @@ maldet::ensure: present
 maldet::service_ensure: running
 maldet::daily_scan: true
 maldet::mirror_url: https://cdn.rfxn.com/downloads
-maldet::config: {}
 maldet::monitor_paths:
   - /tmp
   - /var/tmp
@@ -32,8 +31,7 @@ maldet::cron_config: {}
 maldet::cleanup_old_install: true
 maldet::manage_epel: true
 
-# Config defaults for Linux Malware Detect > 1.5
-maldet::new_config:
+maldet::config:
   email_alert: false
   email_addr:
     - you@domain.com
@@ -84,30 +82,3 @@ maldet::new_config:
   inotify_verbose: false
   string_length_scan: false
   string_length: 150000
-
-# Config defaults for Linux Malware Detect < 1.5
-maldet::old_config:
-  email_alert: false
-  email_subj: maldet alert from $(hostname)
-  email_addr:
-    - you@domain.com
-  email_ignore_clean: false
-  quar_hits: false
-  quar_clean: true
-  quar_susp: false
-  quar_susp_minuid: 500
-  maxdepth: 15
-  minfilesize: 32
-  maxfilesize: 768k
-  hexdepth: 61440
-  hex_fifo_scan: true
-  hex_fifo_depth: 524288
-  clamav_scan: true
-  public_scan: false
-  string_length_scan: false
-  string_length: 150000
-  inotify_base_watches: 15360
-  inotify_stime: 30
-  inotify_minuid: 500
-  inotify_webdir: public_html
-  inotify_nice: 10

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,23 +12,16 @@ class maldet::config (
   Variant[Enum['disabled', 'users'], Stdlib::Absolutepath] $monitor_mode = $maldet::monitor_mode,
 ) {
 
-  # Versions of maldet < 1.5 use a different set of
-  # config options
-  if versioncmp($maldet::version, '1.5') >= 0 {
-    $default_config = lookup('maldet::new_config', Hash)
-    $merged_config = $default_config + $config
-  } else {
-    $default_config = lookup('maldet::old_config', Hash)
-    $merged_config = $default_config + $config
+  if versioncmp($maldet::version, '1.5') < 0 {
+    fail("Versions of maldet lower than 1.5 are unsupported. The version specified as \$maldet:version is ${maldet::version}")
   }
 
-  $merged_conf = { 'config' => $merged_config }
   file { '/usr/local/maldetect/conf.maldet':
     ensure  => present,
     mode    => '0644',
     owner   => root,
     group   => root,
-    content => epp('maldet/conf.maldet.epp', $merged_conf),
+    content => epp('maldet/conf.maldet.epp', { 'config' => $config }),
   }
 
   # Allow config overrides for daily cron


### PR DESCRIPTION
- drop support for maldet 1.5 (released 7 years ago)
- simplify config since we no longer need new_config and old_config